### PR TITLE
PropType of children should be array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ class typeForm extends React.Component {
  * Validating propTypes
  */
 typeForm.propTypes = {
-  children: React.PropTypes.element.isRequired,
+  children: React.PropTypes.array.isRequired,
   onSubmit: React.PropTypes.func,
   submitBtnText: React.PropTypes.string,
   submitBtnClass: React.PropTypes.string,


### PR DESCRIPTION
I got this error while rendering two simple components using the instructions from the README:

```
warning.js:36Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `typeForm`, expected a single ReactElement.
    in typeForm (created by TypeFormComponent)
    in TypeFormComponent (created by Home)
    in Home (created by RouterContext)
    in section (created by App)
    in div (created by App)
    in App (created by RouterContext)
    in RouterContext (created by Router)
    in Router (created by Root)
    in div (created by Root)
    in Provider (created by Root)
    in Root
```

So I figured the PropType should be an array. 

Thanks for a nice React Component!
